### PR TITLE
Fixed App.js className parameter

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -15,7 +15,7 @@ function App() {
       <Router>
         <Navbar />
         <div
-          classname="main-box"
+          className="main-box"
           style={{
             background: "#f1b6dc",
             margin: "3.5rem auto 1.5rem",


### PR DESCRIPTION
Changed `classname` to `className` in `App.js`

- `classname` is not how you're supposed to have it in React